### PR TITLE
Don't abort when failing to get real-time priority

### DIFF
--- a/btif/src/btif_a2dp_sink.cc
+++ b/btif/src/btif_a2dp_sink.cc
@@ -192,7 +192,7 @@ bool btif_a2dp_sink_init() {
 
   /* Schedule the rest of the operations */
   if (!btif_a2dp_sink_cb.worker_thread.EnableRealTimeScheduling()) {
-    LOG(FATAL) << __func__
+    LOG(ERROR) << __func__
                << ": Failed to increase A2DP decoder thread priority";
   }
   btif_a2dp_sink_cb.worker_thread.DoInThread(

--- a/btif/src/btif_a2dp_source.cc
+++ b/btif/src/btif_a2dp_source.cc
@@ -358,7 +358,7 @@ bool btif_a2dp_source_startup(void) {
 static void btif_a2dp_source_startup_delayed() {
   LOG_INFO("%s: state=%s", __func__, btif_a2dp_source_cb.StateStr().c_str());
   if (!btif_a2dp_source_thread.EnableRealTimeScheduling()) {
-    LOG(FATAL) << __func__ << ": unable to enable real time scheduling";
+    LOG(ERROR) << __func__ << ": unable to enable real time scheduling";
   }
   if (!bluetooth::audio::a2dp::init(&btif_a2dp_source_thread)) {
     if (btif_av_is_a2dp_offload_enabled()) {

--- a/hci/src/hci_layer.cc
+++ b/hci/src/hci_layer.cc
@@ -234,7 +234,6 @@ static future_t* hci_module_start_up(void) {
   }
   if (!hci_thread.EnableRealTimeScheduling()) {
     LOG_ERROR("%s unable to make thread RT.", __func__);
-    goto error;
   }
 
   commands_pending_response = list_new(NULL);

--- a/stack/btu/btu_task.cc
+++ b/stack/btu/btu_task.cc
@@ -121,7 +121,7 @@ void main_thread_start_up() {
     LOG(FATAL) << __func__ << ": unable to start btu message loop thread.";
   }
   if (!main_thread.EnableRealTimeScheduling()) {
-    LOG(FATAL) << __func__ << ": unable to enable real time scheduling";
+    LOG(ERROR) << __func__ << ": unable to enable real time scheduling";
   }
 }
 


### PR DESCRIPTION
On some devices (like OP6), for unknown reason, trying to go to realtime
fails with EPERM.
There is no good reason to actually require real-time, so don't fail
when we don't get it
This fixes gabeldorsche on OP6
Not yet legacy bluetooth stack

Change-Id: Id25dac186628e933185bdfd640498004459b375a